### PR TITLE
Upgrade compatible Locust version to 2.5.0, fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cp .env.sample .env
 
 # ... edit ABLY_API_KEY in .env ...
 
-docker-compose up --build
+docker compose up --build
 ```
 
 Visit the Locust web UI at http://localhost:8089, start a load test, and you should see `subscribe` and `publish` events reported by the JavaScript users.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cp .env.sample .env
 
 # ... edit ABLY_API_KEY in .env ...
 
-docker compose up --build
+docker-compose up --build
 ```
 
 Visit the Locust web UI at http://localhost:8089, start a load test, and you should see `subscribe` and `publish` events reported by the JavaScript users.

--- a/example/.env.sample
+++ b/example/.env.sample
@@ -1,3 +1,3 @@
-COMPOSE_PROJECT_NAME='ably-locust-example'
+COMPOSE_PROJECT_NAME=ably-locust-example
 
-ABLY_API_KEY='<api-key>'
+ABLY_API_KEY=<api-key>

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:2.4.3
+    image: locustio/locust:2.5.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@
  *
  * See https://github.com/locustio/locust/blob/2.4.3/locust/runners.py#L879-L886
  */
-export const PROTOCOL_VERSION = '2.4.3';
+export const PROTOCOL_VERSION = '2.5.0';
 
 /**
  * The interval between successive heartbeats.


### PR DESCRIPTION
This sets the Locust version to use to 2.5.0.

Fixes #1.