### PR TITLE
Make tests use a running Locust instance instead of starting a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ worker.register('ExampleUser', () => new User());
 
 worker.run();
 ```
+
+## Testing
+
+Start an instance of Locust and run the tests:
+
+```
+cd tests
+
+docker compose up --build
+
+npm test
+```

--- a/tests/Worker.test.ts
+++ b/tests/Worker.test.ts
@@ -3,21 +3,14 @@ import { waitUntil, LocustProcess } from './helpers';
 
 jest.setTimeout(15000);
 
-let locust: LocustProcess;
+export const zeromq_uri = 'tcp://127.0.0.1:5557';
 
-beforeEach(() => {
-  locust = new LocustProcess();
-  return locust.start();
-});
-
-afterEach(() => {
-  return locust.stop();
-});
+let locust: LocustProcess = new LocustProcess();
 
 test('run a load test', async () => {
   // create a worker
   const worker = new Worker({
-    locustUri: locust.zeromq_uri,
+    locustUri: zeromq_uri,
     workerID:  'test',
   });
 
@@ -55,4 +48,7 @@ test('run a load test', async () => {
 
   // check 10 users stop
   await waitUntil(userCountIs(0), 500, 10000);
+
+  // stop the worker
+  await worker.quit();
 });

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  locust:
+    image: locustio/locust:2.5.0
+    environment:
+      LOCUST_HOST: http://locust
+      LOCUST_MODE_MASTER: "true"
+    volumes:
+      - ./helpers/locustfile.py:/home/locust/locustfile.py
+    ports:
+      - 8089:8089
+      - 5557:5557

--- a/tests/helpers/LocustProcess.ts
+++ b/tests/helpers/LocustProcess.ts
@@ -1,6 +1,6 @@
-import { spawn, ChildProcess } from 'child_process';
-
 import got from 'got';
+
+const web_uri = 'http://127.0.0.1:8089';
 
 /**
  * A Locust API response from GET /stats/requests.
@@ -31,96 +31,24 @@ interface SpawnResponse {
  * Expects 'locust' to be in $PATH.
  */
 export class LocustProcess {
-  cmd?: ChildProcess;
-  stdout: string;
-  stderr: string;
-  web_uri: string;
-  zeromq_uri: string;
-
-  constructor() {
-    this.stdout = '';
-    this.stderr = '';
-    this.web_uri = 'http://127.0.0.1:18089';
-    this.zeromq_uri = 'tcp://127.0.0.1:15557';
-  }
-
-  /**
-   * Start Locust as a child process and return a Promise which resolves when
-   * Locust prints 'Starting Locust' to stderr.
-   */
-  start(): Promise<void> {
-    this.cmd = spawn(
-      'locust',
-      [
-        '--locustfile', `${__dirname}/locustfile.py`,
-        '--master',
-        '--master-bind-host=127.0.0.1',
-        '--master-bind-port=15557',
-        '--web-host=127.0.0.1',
-        '--web-port=18089',
-      ],
-    );
-
-    return new Promise((resolve, reject) => {
-      this.cmd!.stdout!.on('data', (data) => {
-        this.stdout += data;
-      });
-      this.cmd!.stderr!.on('data', (data) => {
-        this.stderr += data;
-
-        if(data.includes('Starting Locust')) {
-          resolve();
-        }
-      });
-      this.cmd!.on('error', (err) => {
-        reject(new Error(`Locust failed to start; error=${err} stdout=${this.stdout} stderr=${this.stderr}`));
-      });
-      this.cmd!.on('close', (code) => {
-        reject(new Error(`Locust failed to start; code=${code} stdout=${this.stdout} stderr=${this.stderr}`));
-      });
-    });
-  }
-
-  /**
-   * Send a SIGTERM signal to the Locust process and return a Promise which
-   * resolves when the process exits.
-   */
-  stop(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if(!this.cmd) {
-        resolve();
-        return;
-      }
-      this.cmd.on('close', (code) => {
-        if(code == 0) {
-          resolve();
-        } else {
-          reject(new Error(`Locust exited with non-zero exit status: ${code}`));
-        }
-      });
-
-      this.cmd.kill();
-    });
-  }
-
   /**
    * Retrieve stats from the Locust web API.
    */
   stats(): Promise<StatsResponse> {
-    return got.get(`${this.web_uri}/stats/requests`).json();
+    return got.get(`${web_uri}/stats/requests`).json();
   }
 
   /**
    * Start a load test using the Locust web API.
    */
   startLoadTest(req: SpawnRequest): Promise<SpawnResponse> {
-    return got.post(`${this.web_uri}/swarm`, { form: req }).json();
+    return got.post(`${web_uri}/swarm`, { form: req }).json();
   }
 
   /**
    * Stop a load test using the Locust web API.
    */
   stopLoadTest(): Promise<SpawnResponse> {
-    return got.get(`${this.web_uri}/stop`).json();
+    return got.get(`${web_uri}/stop`).json();
   }
 }


### PR DESCRIPTION
This makes tests use a running Locust instance instead of starting a new one. Note that this won't work if multiple tests are running at the same time.