### PR TITLE
Add user index

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ class User {
   }
 }
 
-worker.register('ExampleUser', () => new User());
+worker.register('ExampleUser', (index) => new User());
 
 worker.run();
 ```

--- a/example/index.ts
+++ b/example/index.ts
@@ -13,8 +13,8 @@ const worker = new Worker({
 // Register a function to intialise users for each user class defined in
 // locustfile.py
 const { Publisher, Subscriber } = require('./users');
-worker.register('Subscriber', () => new Subscriber(worker.stats));
-worker.register('Publisher',  () => new Publisher(worker.stats));
+worker.register('Subscriber', (index: number) => new Subscriber(worker.stats));
+worker.register('Publisher',  (index: number) => new Publisher(worker.stats));
 
 // Quit the worker when receiving a termination signal.
 process.on('SIGTERM', () => worker.quit());

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -61,7 +61,7 @@ interface User {
 /**
  * A function which is registered with a worker to initialise a User.
  */
-type UserFn = () => User;
+type UserFn = (index: number) => User;
 
 /**
  * A Locust worker which connects to a Locust master ZeroMQ socket and spawns
@@ -149,7 +149,7 @@ export class Worker {
   /**
    * Register a function to initialise users of the given class name.
    */
-  register(userClass: string, userFn: () => User) {
+  register(userClass: string, userFn: (index: number) => User) {
     this.userFns[userClass] = userFn;
   }
 
@@ -296,7 +296,8 @@ export class Worker {
   startUsers(userClass: string, userFn: UserFn, count: number) {
     for (let i = 0; i < count; i++) {
       try {
-        const user = userFn();
+        const index = this.users[userClass].length;
+        const user = userFn(index);
         user.start();
         this.users[userClass].push(user);
       } catch (err) {

--- a/tests/Worker.test.ts
+++ b/tests/Worker.test.ts
@@ -17,8 +17,9 @@ test('run a load test', async () => {
   // register a TestUser which increases/decreases userCount when it
   // starts/stops.
   let userCount = 0;
-  worker.register('TestUser', () => ({
+  worker.register('TestUser', (index: number) => ({
     start: () => {
+      expect(index).toBe(userCount);
       userCount += 1;
     },
     stop: () => {


### PR DESCRIPTION
A user index allows every user to behave differently, for instance you might want to perform a load test where the first user is the only one publishing messages.